### PR TITLE
fix: console vim support 256 colors, dark background (see README)

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,8 @@
+install this plugin - gvim colorscheme to vim:
+https://github.com/vim-scripts/CSApprox
+
+add to vimrc file 256 colors support:
+set t_Co=256
+colorscheme vividchalk
+
+colors work identical on gvim and vim.

--- a/colors/vividchalk.vim
+++ b/colors/vividchalk.vim
@@ -7,9 +7,7 @@
 " Based on the Vibrank Ink theme for TextMate
 " Distributable under the same terms as Vim itself (see :help license)
 
-if has("gui_running")
-    set background=dark
-endif
+set background=dark
 hi clear
 if exists("syntax_on")
    syntax reset


### PR DESCRIPTION
tested in gnome-terminal
