### PR TITLE
Change ColorColumn, CursorLine, and CursorColumn to use s:hibg

### DIFF
--- a/colors/vividchalk.vim
+++ b/colors/vividchalk.vim
@@ -111,9 +111,9 @@ highlight StatusLineNC  guifg=#444444 guibg=#aaaaaa gui=none ctermfg=Black cterm
 highlight Ignore        ctermfg=Black
 highlight WildMenu      guifg=Black   guibg=#ffff00 gui=bold ctermfg=Black ctermbg=Yellow cterm=bold
 highlight Cursor        guifg=Black guibg=White ctermfg=Black ctermbg=White
-highlight CursorLine    guibg=#333333 guifg=NONE
-highlight CursorColumn  guibg=#333333 guifg=NONE
-highlight ColorColumn   guibg=#333333 guifg=NONE
+call s:hibg("ColorColumn","#333333","DarkGrey",81)
+call s:hibg("CursorLine","#333333","DarkGrey",81)
+call s:hibg("CursorColumn","#333333","DarkGrey",81)
 highlight NonText       guifg=#404040 ctermfg=8
 highlight SpecialKey    guifg=#404040 ctermfg=8
 highlight Directory     none


### PR DESCRIPTION
The colors were not being set on terminals, resulting in ugly defaults when those features are used.
