### PR TITLE
Making search highlight easier to see

### DIFF
--- a/colors/vividchalk.vim
+++ b/colors/vividchalk.vim
@@ -120,7 +120,7 @@ highlight Directory     none
 high link Directory     Identifier
 highlight ErrorMsg      guibg=Red ctermbg=DarkRed guifg=NONE ctermfg=NONE
 highlight Search        guifg=NONE ctermfg=NONE gui=none cterm=none
-call s:hibg("Search"    ,"#555555","DarkBlue",81)
+call s:hibg("Search"    ,"#555555","DarkBlue","grey")
 highlight IncSearch     guifg=White guibg=Black ctermfg=White ctermbg=Black
 highlight MoreMsg       guifg=#00AA00 ctermfg=Green
 highlight LineNr        guifg=#DDEEFF ctermfg=White


### PR DESCRIPTION
The current colorscheme makes it difficult to see search highlighting on a black background. I have provided one possible solution to this problem.
